### PR TITLE
Make leading slash optional.

### DIFF
--- a/example/http.ts
+++ b/example/http.ts
@@ -103,6 +103,7 @@ const app = new KingWorld<{
 		}>(({ query }) => {
 			if (query?.name === 'aom') return 'Hi saltyaom'
 		})
+			.get('/', () => 'GROUP ROOT')
 			.get('/hi', () => 'HI GROUP')
 			.get('/kingworld', () => 'Welcome to KINGWORLD')
 			.get('/fbk', () => 'FuBuKing')

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,14 @@ import MedleyRouter from '@medley/router'
 
 import Context from './context'
 import { mapResponse, mapEarlyResponse } from './handler'
-import { mergeHook, isPromise, clone, mapQuery, getPath } from './utils'
+import {
+	mergeHook,
+	isPromise,
+	clone,
+	mapQuery,
+	getPath,
+	leadingSlash
+} from './utils'
 
 import type {
 	Handler,
@@ -66,12 +73,12 @@ export default class KingWorld<
 	) {
 		this.routes.push({
 			method,
-			path,
+			path: leadingSlash(path),
 			handler,
 			hooks: mergeHook(clone(this.hook) as Hook, hook as RegisterHook)
 		})
 
-		this.router.register(path)[method] = {
+		this.router.register(leadingSlash(path))[method] = {
 			handle: handler,
 			hooks: mergeHook(clone(this.hook) as Hook, hook as RegisterHook)
 		}
@@ -130,7 +137,12 @@ export default class KingWorld<
 
 		Object.values(instance.routes).forEach(
 			({ method, path, handler, hooks }) => {
-				this._addHandler(method, `${prefix}${path}`, handler, hooks)
+				this._addHandler(
+					method,
+					`${prefix}${leadingSlash(path)}`,
+					handler,
+					hooks
+				)
 			}
 		)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import {
 	clone,
 	mapQuery,
 	getPath,
-	leadingSlash
+	parseSlash
 } from './utils'
 
 import type {
@@ -73,12 +73,12 @@ export default class KingWorld<
 	) {
 		this.routes.push({
 			method,
-			path: leadingSlash(path),
+			path: parseSlash(path),
 			handler,
 			hooks: mergeHook(clone(this.hook) as Hook, hook as RegisterHook)
 		})
 
-		this.router.register(leadingSlash(path))[method] = {
+		this.router.register(parseSlash(path))[method] = {
 			handle: handler,
 			hooks: mergeHook(clone(this.hook) as Hook, hook as RegisterHook)
 		}
@@ -139,7 +139,7 @@ export default class KingWorld<
 			({ method, path, handler, hooks }) => {
 				this._addHandler(
 					method,
-					`${prefix}${leadingSlash(path)}`,
+					`${prefix}${parseSlash(path)}`,
 					handler,
 					hooks
 				)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,7 +32,7 @@ export const clone = <T extends Object | any[] = Object | any[]>(
 // 	return i === -1 ? [s, ''] : [s.slice(0, i), s.slice(i + 1)]
 // }
 
-export const leadingSlash = (url: string): string => {
+export const parseSlash = (url: string): string => {
 	if (url === '/') return url
 
 	const leading = url.endsWith('/')
@@ -44,7 +44,7 @@ export const leadingSlash = (url: string): string => {
 export const getPath = (url: string): string => {
 	const queryIndex = url.indexOf('?')
 
-	return leadingSlash(
+	return parseSlash(
 		url.substring(
 			url.charCodeAt(0) === 47 ? 0 : url.indexOf('/', 11),
 			queryIndex === -1 ? url.length : queryIndex

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,12 +32,23 @@ export const clone = <T extends Object | any[] = Object | any[]>(
 // 	return i === -1 ? [s, ''] : [s.slice(0, i), s.slice(i + 1)]
 // }
 
+export const leadingSlash = (url: string): string => {
+	if (url === '/') return url
+
+	const leading = url.endsWith('/')
+	const leadingPos = url.lastIndexOf('/')
+
+	return leading ? url.slice(0, leadingPos) + url.slice(leadingPos + 1) : url
+}
+
 export const getPath = (url: string): string => {
 	const queryIndex = url.indexOf('?')
 
-	return url.substring(
-		url.charCodeAt(0) === 47 ? 0 : url.indexOf('/', 11),
-		queryIndex === -1 ? url.length : queryIndex
+	return leadingSlash(
+		url.substring(
+			url.charCodeAt(0) === 47 ? 0 : url.indexOf('/', 11),
+			queryIndex === -1 ? url.length : queryIndex
+		)
 	)
 }
 


### PR DESCRIPTION
This will make the leading slashes (mainly used for groups) completely optional.
Meaning both `http://localhost:8080/group/` and `http://localhost:8080/group` will both point to the same route.

If you don't want the leading slash, a simple unwrapping of the `getPath` returning the `leadingSlash` function will do.

All tests pass.
<img width="281" alt="image" src="https://user-images.githubusercontent.com/20338746/190889390-c1c33515-e4a9-488e-9ff3-c7825ef6d930.png">
